### PR TITLE
FOpts data now resides in publishDataUpRequest.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,4 +44,4 @@ require (
 	pack.ag/amqp v0.12.1
 )
 
-replace github.com/brocaar/chirpstack-api/go/v3 => ../chirpstack-api/go
+//replace github.com/brocaar/chirpstack-api/go/v3 => ../chirpstack-api/go

--- a/go.mod
+++ b/go.mod
@@ -45,3 +45,4 @@ require (
 )
 
 //replace github.com/brocaar/chirpstack-api/go/v3 => ../chirpstack-api/go
+replace github.com/brocaar/chirpstack-api/go/v3 => github.com/BerdinEge/chirpstack-api/go/v3 v3.12.3

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX
 github.com/Azure/go-autorest v11.0.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v12.0.0+incompatible h1:N+VqClcomLGD/sHb3smbSYYtNMgKpVV3Cd5r5i8z6bQ=
 github.com/Azure/go-autorest v12.0.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/BerdinEge/chirpstack-api/go/v3 v3.12.3 h1:o8vPhehvdZaKGk+pi9JREkp6GjRL5bTiTRvkTxzN+Ac=
+github.com/BerdinEge/chirpstack-api/go/v3 v3.12.3/go.mod h1:v8AWP19nOJK4rwJsr1+weDfpUc4UNLbRh8Eygn4Oh00=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/internal/uplink/data/data.go
+++ b/internal/uplink/data/data.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -607,6 +608,16 @@ func sendFRMPayloadToApplicationServer(ctx *dataContext) error {
 			return fmt.Errorf("expected type *lorawan.DataPayload, got %T", ctx.MACPayload.FRMPayload[0])
 		}
 		publishDataUpReq.Data = dataPL.Bytes
+	}
+	if len(ctx.MACPayload.FHDR.FOpts) > 0 {
+		macPL, ok := ctx.MACPayload.FHDR.FOpts[0].(*lorawan.MACCommand)
+		if !ok {
+			return fmt.Errorf("expected type *lorawan.MACCommand, got %T", ctx.MACPayload.FHDR.FOpts[0])
+		}
+		out, err := json.Marshal(macPL)
+		if err == nil && out != nil {
+			publishDataUpReq.Macdata = out
+		}
 	}
 
 	go func(ctx context.Context, asClient as.ApplicationServerServiceClient, publishDataUpReq as.HandleUplinkDataRequest) {


### PR DESCRIPTION
FOpts data is now pushing to the AS to insert to the loradatastore db.